### PR TITLE
Add simple BlueSky posting client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,17 @@
-# sv
+# BlueSky Post Client
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+This SvelteKit project provides a simple interface to log in to your BlueSky account and publish posts. It uses server routes to call the BlueSky XRPC APIs for authentication and posting.
 
-## Creating a project
+## Development
 
-If you're seeing this, you've probably already done this step. Congrats!
-
-```bash
-# create a new project in the current directory
-npx sv create
-
-# create a new project in my-app
-npx sv create my-app
-```
-
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Install dependencies and start the development server:
 
 ```bash
-npm run dev
-
-# or start the server and open the app in a new browser tab
+npm install
 npm run dev -- --open
 ```
 
-## Building
+## Features
 
-To create a production version of your app:
-
-```bash
-npm run build
-```
-
-You can preview the production build with `npm run preview`.
-
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+- Log in using your BlueSky handle and app password
+- Create text posts from the browser

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,55 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+  let identifier = '';
+  let password = '';
+  let text = '';
+  let accessJwt = '';
+  let did = '';
+  let loggedIn = false;
+
+  async function login() {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identifier, password })
+    });
+
+    if (!res.ok) {
+      alert('Login failed');
+      return;
+    }
+
+    const data = await res.json();
+    accessJwt = data.accessJwt;
+    did = data.did;
+    loggedIn = true;
+  }
+
+  async function post() {
+    const res = await fetch('/api/post', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, accessJwt, did })
+    });
+
+    if (!res.ok) {
+      const err = await res.text();
+      alert('Post failed: ' + err);
+      return;
+    }
+
+    text = '';
+    alert('Post successful');
+  }
+</script>
+
+{#if !loggedIn}
+  <h1>Login to BlueSky</h1>
+  <input placeholder="Handle or email" bind:value={identifier} />
+  <input type="password" placeholder="App password" bind:value={password} />
+  <button on:click={login}>Login</button>
+{:else}
+  <h1>Create Post</h1>
+  <textarea rows="5" cols="50" bind:value={text} placeholder="Write your post here" />
+  <br />
+  <button on:click={post}>Post</button>
+{/if}

--- a/src/routes/api/login/+server.ts
+++ b/src/routes/api/login/+server.ts
@@ -1,0 +1,19 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request }) => {
+  const { identifier, password } = await request.json();
+
+  const res = await fetch('https://bsky.social/xrpc/com.atproto.server.createSession', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ identifier, password })
+  });
+
+  if (!res.ok) {
+    return new Response(await res.text(), { status: res.status });
+  }
+
+  const data = await res.json();
+  return json(data);
+};

--- a/src/routes/api/post/+server.ts
+++ b/src/routes/api/post/+server.ts
@@ -1,0 +1,32 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request }) => {
+  const { text, accessJwt, did } = await request.json();
+
+  const body = {
+    repo: did,
+    collection: 'app.bsky.feed.post',
+    record: {
+      $type: 'app.bsky.feed.post',
+      text,
+      createdAt: new Date().toISOString()
+    }
+  };
+
+  const res = await fetch('https://bsky.social/xrpc/com.atproto.repo.createRecord', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessJwt}`
+    },
+    body: JSON.stringify(body)
+  });
+
+  if (!res.ok) {
+    return new Response(await res.text(), { status: res.status });
+  }
+
+  const data = await res.json();
+  return json(data);
+};


### PR DESCRIPTION
## Summary
- replace placeholder README with project info
- add login and post routes that wrap BlueSky XRPC calls
- build a minimal Svelte page for logging in and posting

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc9e4ec288323affacb6e4591fbd1